### PR TITLE
Mount db to new location of data

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       dockerfile: "./Dockerfile"
       context: "."
     volumes:
-      - "./db:/data"
+      - "./db:/decentraland/data"
     environment:
       RPC_API_KEY: "38Dpwnjsj2zn3QETJ6GKv8YkHomA"
     ports:


### PR DESCRIPTION
After the fix on `bin/start` in https://github.com/decentraland/bronzeage-node/commit/833860d9c01f22788054af8cd4bbfd623ecbe9f9, the `docker-compose` config is saving its data to directory that gets wiped with every restart of it. This PR should fix it by mounting a local (in host) directory `./db` to `/decentraland/data` inside the container.