### PR TITLE
Update contentdb.js

### DIFF
--- a/lib/blockchain/contentdb.js
+++ b/lib/blockchain/contentdb.js
@@ -139,20 +139,20 @@ ContentDB.prototype.save = co(function* save(x, y, hash, stream, isCurrent) {
 });
 
 ContentDB.prototype.fetch = function fetch(x, y, hash) {
-
-  // check if we already have that file
-  if (fs.existsSync(this._pathFor(x, y, hash))) {
-    return;
-  }
-
+  
   // if null content, save default tile without downloading torrent
   if (hash === constants.NULL_HASH) {
     return;
   }
 
-  var self = this;
-
   hash = hash.substr(0, 40);
+
+  // check if we already have that file
+  if (fs.existsSync(this._pathFor(x, y, hash))) {
+    return;
+  }
+  
+  var self = this;
 
   if (this.webtorrent.torrents.filter(t => t.infoHash == hash).length > 0) {
     return;


### PR DESCRIPTION
hash.subtr was placed at the wrong place, so ALL tiles with content was redownloaded at each restart of the node