### PR TITLE
Print original error message in lib/db/backends.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,8 @@ There's two options for installing running a node: [with docker](#run-a-node-usi
 ### Run a node manually
 1. clone the repo:
 `git clone https://github.com/decentraland/bronzeage-node.git` && cd bronzeage-node
-2. Install NodeJS:
-See https://nodejs.org/en/.
+2. Install [NodeJS](https://nodejs.org/en/).
+The current decentraland node requires NodeJS v7.4.0 or higher. See [nvm](http://nvm.sh) for version management.
 3. install dependencies:
 `apt-get update && apt-get install -y --no-install-recommends xvfb libgtk2.0-0 libxtst-dev libxss-dev libgconf2-dev libnss3 libasound2-dev`
 4. install npm modules

--- a/lib/db/backends.js
+++ b/lib/db/backends.js
@@ -14,6 +14,6 @@ exports.get = function get(name) {
   try {
     return require(name);
   } catch (e) {
-    throw new Error('Database backend "' + name + '" not found.');
+    throw new Error(`Database backend "${name}" could not be loaded:\n${e}`);
   }
 };


### PR DESCRIPTION
I had an older version of node an this `catch` was hiding a helpful error message.